### PR TITLE
Fixing webkit blur problem

### DIFF
--- a/tests/views/wysiwyg_editor_view.js
+++ b/tests/views/wysiwyg_editor_view.js
@@ -1,0 +1,49 @@
+// ==========================================================================
+// Project:   SC.WYSIWYG
+// Copyright: ©2010 SproutCore
+// ==========================================================================
+
+var pane, editor;
+
+module('SC.WYSIWYGEditorView', {
+
+    setup: function() {
+
+        pane = SC.ControlTestPane.create({
+            height: 900,
+            childViews: ['editorView', 'otherView'],
+            editorView: SC.WYSIWYGEditorView.design(),
+            otherView: SC.View.design()
+        });
+
+        pane.append(); // make visible so it will have root responder
+
+        // mock the default responder
+        SC.RootResponder.responder.defaultResponder = SC.Object.create({
+            sendAction: function() {}
+        });
+
+    },
+
+    teardown: function() {
+        pane.removeAllChildren();
+    }
+
+});
+
+test('Editor focuses to / blurs from `firstResponder`', function() {
+
+    var otherView = pane.getPath('otherView');
+    SC.run(function() {
+        pane.getPath('editorView').focus();
+    });
+
+    equals(pane.getPath('editorView.isFirstResponder'), YES, 'The editor `isFirstResponder`');
+
+    SC.run(function() {
+        pane.getPath('editorView').blur();
+    });
+
+    equals(pane.getPath('editorView.isFirstResponder'), NO, 'The editor is NOT `isFirstResponder`');
+
+});

--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -790,6 +790,12 @@ SC.WYSIWYGEditorView = SC.View.extend({
 
   /** @private*/
   willLoseFirstResponder: function () {
+
+    // There is an apparent bug in WebKit that prevents contenteditable elements from properly giving up
+    // focus when told to blur. As a work around, we clear the selection, which frees up the element to blur.
+    var sel = document.getSelection();
+    sel.removeAllRanges();
+
     this.$inner.blur();
   },
 


### PR DESCRIPTION
@publickeating provided a workaround for a known WebKit bug involving failure to properly blur `contenteditable` divs.

I've added a unit test to exercise the focus/blur behavior. However, I have to admit that within the `SC.CoreTestPane`, the actual blur problem I'm trying to exercise is not apparent.
