### PR TITLE
Allows for link clicks to trigger when editor is not first responder

### DIFF
--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -50,13 +50,11 @@ SC.WYSIWYGEditorView = SC.View.extend({
   /** @deprecated Use `hint` instead. */
   defaultValue: null,
 
-  /**
+  /** @private
    When running unit tests, a link click may trigger a call to `window.open`.
 
    This flag allows the view to prevent this since we don't want unit tests actually
    opening windows.
-
-   TODO Is there a better way to handle this in a more generalized way? e.g. `@debug`?
 
    @type Boolean
    @default YES
@@ -336,7 +334,7 @@ SC.WYSIWYGEditorView = SC.View.extend({
   computeHeight: function () {
 
     // If there's no editable content, bail.
-    if(!this.$inner || this.$inner[0]) { return 0; }
+    if(!this.$inner || !this.$inner[0]) { return 0; }
 
     // Get the height of the editable element.
     var layer = this.$inner[0];
@@ -742,7 +740,9 @@ SC.WYSIWYGEditorView = SC.View.extend({
       && !this.get('hasFirstResponder')
     ) {
       if(this.get('_followRedirects')) { window.open(evt.target.href, '_blank'); }
-      return NO;
+
+      // Instead of returning NO, indicate the view handled the event specially
+      evt.preventDefault();
     }
     else if (evt.target === this.get('layer')) {
       this._mouseDownOutsideOfEditor = YES; // TODO: yeah this is kind of hacky
@@ -812,7 +812,7 @@ SC.WYSIWYGEditorView = SC.View.extend({
   /** @private*/
   didBecomeFirstResponder: function () {
     // Need closure on the inner element for unit test.
-    //  Othersiws, the element is null by time `invokeNext` fires.
+    //  Otherwise, the element is null by time `invokeNext` fires.
     var inner = this.$inner;
     this.invokeNext(function () {
       inner.focus();


### PR DESCRIPTION
Allows for link clicks to trigger a window.open call to target _blank. Currently, clicking a link simply puts the editor into isFirstResponder, which is not consistent with user expectation.

The approach here is to simply modify the editor's mouseDown event handler to detect whether the event.target is an anchor tag AND whether the editor has isFirstResponder.

A user story here might be "As a user, if I click a link in the editor while NOT editing content, the link should open a new window/tab and display the linked webpage." And "... if I click a link while IN editing mode, place the caret within the link text so that I can modify the link using the toolbar tool, if needed."

Unit test provided.
