### PR TITLE
Editor should not accept first respondership if disabled

### DIFF
--- a/tests/views/wysiwyg_editor_view.js
+++ b/tests/views/wysiwyg_editor_view.js
@@ -86,3 +86,23 @@ test('Anchor tag within editor markup', function() {
     // Just turning the flag back for manual poking/prodding in the SC test runner
     editorView._followRedirects = YES;
 });
+
+test('Editor accepts first respondership when enabled', function() {
+
+    var editorView = pane.get('editorView');
+
+    ok(editorView.get('isEnabled'), 'Verify that editor is enabled');
+    ok(editorView.get('acceptsFirstResponder'), 'Editor accepts first respondership');
+});
+
+test('Editor refuses first respondership when disabled', function() {
+
+    var editorView = pane.get('editorView');
+
+    SC.run(function() {
+        editorView.set('isEnabled', false);
+    });
+
+    ok(!editorView.get('isEnabled'), 'Verify that editor is not enabled');
+    ok(!editorView.get('acceptsFirstResponder'), 'Editor does not accept first respondership');
+});

--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -132,12 +132,13 @@ SC.WYSIWYGEditorView = SC.View.extend({
   isTextSelectable: YES,
 
   /**
-   We want the editor to respond to key events
+   We want the editor to respond to key events when it is enabled
 
    @type Boolean
-   @default YES
    */
-  acceptsFirstResponder: YES,
+  acceptsFirstResponder: function() {
+    return this.get('isEnabledInPane');
+  }.property('isEnabledInPane').cacheable(),
 
   // ..........................................................
   // INTERNAL SUPPORT


### PR DESCRIPTION
Even though `SC.WYSIWYGEditorView` can be enabled and disabled (and its `contentEditable` is updated accordingly), it still accepts first respondership even when it is disabled.

This branch fixes this problem so that it does not accept first respondership if it is disabled.