### PR TITLE
In Firefox, don't disable image resizable unless editor is enabled

### DIFF
--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -195,14 +195,21 @@ SC.WYSIWYGEditorView = SC.View.extend({
   init: function () {
     sc_super();
     this.undoManager = SC.UndoManager.create();
+  },
 
+  /** @private */
+  _isEnabledInPaneDidChange: function() {
     // Firefox: Disable image resizing
     if (SC.browser.isMozilla) {
       this.invokeLast(function () {
-        document.execCommand("enableObjectResizing", false, false);
+        // need to make sure editor is actually editable, otherwise Firefox will
+        // throw an error if no element on the page is contentEditable
+        if (this.get("isEnabledInPane")) {
+            document.execCommand("enableObjectResizing", false, false);
+        }
       });
     }
-  },
+  }.observes('isEnabledInPane'),
 
   /** @private */
   destroy: function () {


### PR DESCRIPTION
This is a pretty obscure but that occurs only in Firefox when the editor view is disabled.

Specifically, this code causes an `NS_ERROR_FAILURE` to be thrown:

```
            document.execCommand("enableObjectResizing", false, false);
```

I think this happens because the browser finds no element that is `contentEditable` and so it freaks out. An alternative solution is to enable `document.designMode` in Firefox, but there might have other unintended consequences so I decided not to go down that route.
