### PR TITLE
Added better checking when query commands in IE

### DIFF
--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -454,25 +454,24 @@ SC.WYSIWYGEditorView = SC.View.extend({
 
         case 'bold':
           return this._searchForParentNamed(aNode, 'B');
-          break;
 
         case 'italic':
           return this._searchForParentNamed(aNode, 'I');
-          break;
 
         default:
           return '';
-          break;
       }
 
     }
     else {
       var ret = false;
       try {
-        ret = document.queryCommandState(commandName);
+        if (document.queryCommandSupported(commandName) && document.queryCommandEnabled(commandName)) {
+            ret = document.queryCommandState(commandName);
+        }
       }
       catch (e) {
-        SC.error('Quering for command state failed: ' + commandName);
+        SC.error('Querying for command state failed: ' + commandName);
       }
       return ret;
     }
@@ -521,7 +520,16 @@ SC.WYSIWYGEditorView = SC.View.extend({
       }
     }
     else {
-      return document.queryCommandValue(commandName);
+      var ret = false;
+      try {
+        if (document.queryCommandSupported(commandName) && document.queryCommandEnabled(commandName)) {
+            ret = document.queryCommandValue(commandName);
+        }
+      }
+      catch (e) {
+        SC.error('Querying for command value failed: ' + commandName);
+      }
+      return ret;
     }
   },
 


### PR DESCRIPTION
Currently in IE (10 and 11), there are some error output when typing:

```
Quering for command state failed: link
```

We need to check that these commands are supported and enabled before querying the command state.
