### PR TITLE
Fixes a Firefox problem where using the editor disables much of the application.

### DIFF
--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -197,11 +197,11 @@ SC.WYSIWYGEditorView = SC.View.extend({
     this.undoManager = SC.UndoManager.create();
 
     // Firefox: Disable image resizing
-    if (SC.browser.isMozilla) {
-      this.invokeLast(function () {
-        document.execCommand("enableObjectResizing", false, false);
-      });
-    }
+    // if (SC.browser.isMozilla) {
+    //   this.invokeLast(function () {
+    //     document.execCommand("enableObjectResizing", false, false);
+    //   });
+    // }
   },
 
   /** @private */


### PR DESCRIPTION
If the editor is used in a containerview, such as the tab view, the editor not only doesn't work, but also disables most of the application around it, or creates weird behavior. In this case the styling of the segmented buttons falls apart, where the state of the buttons doesn't reflect the actual state of the tab view.

Before this PR is merged, it should be tested whether this only happens in a container view. Also there should be tests to see whether older firefox versions still need.
