### PR TITLE
Added check to make sure the range selected is inside the editor

### DIFF
--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -532,6 +532,12 @@ SC.WYSIWYGEditorView = SC.View.extend({
       if (sel.getRangeAt && sel.rangeCount) {
         // If any text is selected, remove it.
         range = sel.getRangeAt(0);
+
+        // If the range is outside the editor then set it back
+        if (!this.rangeIsInsideEditor(range)) {
+          range = this.selectNodeContents();
+        }
+
         range.deleteContents();
 
         // The dummy div element is used to turn the HTML into DOM, which is then removed and appended to


### PR DESCRIPTION
In some instances the range will be set outside the editor and cause the link to be inserted at whatever location the range is set to, causing links to be inserted into strange places.  You can observe this by entering text into a normal field, then clicking the add link button without first setting your cursor inside the WYSIWYG.  This update will force the range to be set to the editor if it is not already.