### PR TITLE
Fixed bug when calling allowDefault() on browser event rather SC.Event

### DIFF
--- a/views/wysiwyg_editor_view.js
+++ b/views/wysiwyg_editor_view.js
@@ -993,24 +993,23 @@ SC.WYSIWYGEditorView = SC.View.extend({
 
   /** @private*/
   paste: function (evt) {
-    // We need to use originalEvent to be able to access the clipboardData property
-    var evt = evt.originalEvent,
+    var clipboardData = evt.originalEvent.clipboardData,
       pasteAsPlainText = this.get('pasteAsPlainText');
 
-    if (evt.clipboardData) {
+    if (clipboardData) {
       var data;
       if (pasteAsPlainText) {
-        data = evt.clipboardData.getData('text');
+        data = clipboardData.getData('text');
       }
       else {
-        data = evt.clipboardData.getData('text/html');
+        data = clipboardData.getData('text/html');
         if (data.indexOf('<body>') !== -1) {
           data = data.substring(data.indexOf('<body>'), data.indexOf('</body>'));
         }
 
         // some times text can be plain
         if (!data) {
-          data = evt.clipboardData.getData('text');
+          data = clipboardData.getData('text');
         }
       }
       this.insertHtmlAtCaret(data, false);


### PR DESCRIPTION
When pasting, there's a bug where we call `allowDefault()` on the browser's event object rather than `SC.Event`.

Details: the original code assigns `evt = evt.originalEvent`, where `originalEvent` is a browser event object. However, later on, if that event doesn't support `clipboardData` (on [line 1022](https://github.com/sproutcore/rich-text-editor/blob/a9fce0482d2b14b8d30c753199734fe63bb59e3f/views/wysiwyg_editor_view.js#L1022)), the code calls `allowDefault()` on that browser object, even though `allowDefault()` is an `SC.Event` method.

The fix here is to avoid reassigning `evt`, so that `evt` remains the `SC.Event` instance.